### PR TITLE
Harden gallery display against invalid data

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -621,13 +621,16 @@ async function fetchGallery() {
 
 function displayGallery(photos) {
     const galleryGrid = document.getElementById('gallery-grid');
-    
-    if (photos.length === 0) {
+
+    // Guard against null/undefined or non-array inputs
+    const photoArray = Array.isArray(photos) ? photos : [];
+
+    if (photoArray.length === 0) {
         galleryGrid.innerHTML = '<div class="gallery-empty">No photos yet! Take your first snap! 📸</div>';
         return;
     }
-    
-    galleryGrid.innerHTML = photos.map(photo => {
+
+    galleryGrid.innerHTML = photoArray.map(photo => {
         // Create thumbnail URL with Vercel image optimization
         const thumbnailUrl = `${photo.url}?width=300&height=225&fit=cover&quality=80`;
         


### PR DESCRIPTION
## Summary
- Prevent gallery rendering from crashing when API returns null or invalid photo data
- Handle missing or malformed arrays by defaulting to an empty list before rendering

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897c7b3b9e88324ab9856e88a22576f