### PR TITLE
Use Node-style handlers for upload and gallery APIs

### DIFF
--- a/api/gallery.js
+++ b/api/gallery.js
@@ -1,42 +1,34 @@
 const { supabase } = require('../lib/supabase');
 
-export default async function handler(request) {
+module.exports = async (req, res) => {
   console.log('Gallery API: Function started');
-  
+
   // Add CORS headers
-  const headers = {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Cache-Control': 'no-cache, no-store, must-revalidate',
-  };
-  
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+
   // Handle OPTIONS request for CORS
-  if (request.method === 'OPTIONS') {
-    return new Response(null, { status: 200, headers });
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
   }
 
-  if (request.method !== 'GET') {
-    return new Response(
-      JSON.stringify({ error: 'Method not allowed' }),
-      {
-        status: 405,
-        headers,
-      }
-    );
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
   }
 
   try {
     console.log('Gallery API: Fetching from Supabase storage');
-    
+
     // List all files from Supabase storage
     const { data: files, error } = await supabase.storage
       .from('photos')
       .list('', {
         limit: 100,
         offset: 0,
-        sortBy: { column: 'created_at', order: 'desc' }
+        sortBy: { column: 'created_at', order: 'desc' },
       });
 
     if (error) {
@@ -45,11 +37,11 @@ export default async function handler(request) {
     }
 
     // Transform files into photo objects with public URLs
-    const photos = files.map(file => {
-      const { data: { publicUrl } } = supabase.storage
-        .from('photos')
-        .getPublicUrl(file.name);
-      
+    const photos = files.map((file) => {
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from('photos').getPublicUrl(file.name);
+
       return {
         url: publicUrl,
         filename: file.name,
@@ -60,31 +52,18 @@ export default async function handler(request) {
 
     console.log('Gallery API: Found', photos.length, 'photos in Supabase');
 
-    return new Response(
-      JSON.stringify({
-        success: true,
-        photos,
-        count: photos.length,
-        storage: 'supabase'
-      }),
-      {
-        status: 200,
-        headers,
-      }
-    );
-
+    return res.status(200).json({
+      success: true,
+      photos,
+      count: photos.length,
+      storage: 'supabase',
+    });
   } catch (error) {
     console.error('Gallery API: Error:', error);
-    
-    return new Response(
-      JSON.stringify({
-        error: 'Failed to fetch gallery',
-        message: error.message,
-      }),
-      {
-        status: 500,
-        headers,
-      }
-    );
+
+    return res.status(500).json({
+      error: 'Failed to fetch gallery',
+      message: error.message,
+    });
   }
-}
+};

--- a/api/upload.js
+++ b/api/upload.js
@@ -1,110 +1,82 @@
 const { supabase } = require('../lib/supabase');
 
-export default async function handler(request) {
-  console.log('Upload API: Function started, method:', request.method);
-  
+module.exports = async (req, res) => {
+  console.log('Upload API: Function started, method:', req.method);
+
   // Add CORS headers
-  const headers = {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-  };
-  
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
   // Handle OPTIONS request for CORS
-  if (request.method === 'OPTIONS') {
-    return new Response(null, { status: 200, headers });
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
   }
 
-  if (request.method !== 'POST') {
-    return new Response(
-      JSON.stringify({ error: 'Method not allowed' }),
-      {
-        status: 405,
-        headers,
-      }
-    );
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
   }
 
   try {
     console.log('Upload API: Parsing request body...');
-    const body = await request.json();
-    const { image, filename } = body;
+    const { image, filename } = req.body;
 
     if (!image) {
       console.error('Upload API: No image data provided');
-      return new Response(
-        JSON.stringify({ error: 'No image data provided' }),
-        {
-          status: 400,
-          headers,
-        }
-      );
+      return res.status(400).json({ error: 'No image data provided' });
     }
 
     console.log('Upload API: Processing image upload');
-    
+
     // Generate timestamp filename if not provided
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const fileName = filename || `photo-${timestamp}.png`;
-    
+
     // Convert base64 to buffer
     const base64Data = image.replace(/^data:image\/\w+;base64,/, '');
     const buffer = Buffer.from(base64Data, 'base64');
-    
+
     console.log('Upload API: Uploading to Supabase storage...');
-    
+
     // Upload to Supabase storage
     const { data, error } = await supabase.storage
       .from('photos')
       .upload(fileName, buffer, {
         contentType: 'image/png',
-        upsert: false
+        upsert: false,
       });
 
     if (error) {
       console.error('Upload API: Supabase error:', error);
       throw error;
     }
-    
+
     // Get public URL
-    const { data: { publicUrl } } = supabase.storage
-      .from('photos')
-      .getPublicUrl(fileName);
-    
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from('photos').getPublicUrl(fileName);
+
     console.log('Upload API: Success! Stored in Supabase');
 
-    return new Response(
-      JSON.stringify({
-        success: true,
-        url: publicUrl,
-        filename: fileName,
-        path: data.path,
-        storage: 'supabase'
-      }),
-      {
-        status: 200,
-        headers,
-      }
-    );
-
+    return res.status(200).json({
+      success: true,
+      url: publicUrl,
+      filename: fileName,
+      path: data.path,
+      storage: 'supabase',
+    });
   } catch (error) {
     console.error('Upload API: Error:', error);
-    
-    return new Response(
-      JSON.stringify({
-        error: 'Upload failed',
-        message: error.message,
-      }),
-      {
-        status: 500,
-        headers,
-      }
-    );
-  }
-}
 
-export const config = {
+    return res.status(500).json({
+      error: 'Upload failed',
+      message: error.message,
+    });
+  }
+};
+
+module.exports.config = {
   api: {
     bodyParser: {
       sizeLimit: '10mb',


### PR DESCRIPTION
## Summary
- Rewrite `api/upload.js` to export a Node-style `(req, res)` handler and respond using `res.status().json()`
- Do the same for `api/gallery.js` to list images via the Node request/response pattern

## Testing
- `node - <<'NODE' ...` (direct invocation of handlers)
- `npm run dev` *(fails: No existing credentials found. Please run `vercel login` or pass "--token" )*

------
https://chatgpt.com/codex/tasks/task_e_6898fb7bacf083249ac353b5f7c1acdc