### PR TITLE
feat: enable esm

### DIFF
--- a/api/gallery.js
+++ b/api/gallery.js
@@ -1,4 +1,4 @@
-const { supabase } = require('../lib/supabase');
+import { supabase } from '../lib/supabase.js';
 
 export default async function handler(request) {
   console.log('Gallery API: Function started');

--- a/api/test.js
+++ b/api/test.js
@@ -1,11 +1,11 @@
-module.exports = async function handler(request) {
+export default async function handler(request) {
   console.log('Test API: Function started');
-  
+
   const headers = {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*',
   };
-  
+
   return new Response(
     JSON.stringify({
       success: true,
@@ -19,4 +19,5 @@ module.exports = async function handler(request) {
       headers,
     }
   );
-} 
+}
+

--- a/api/upload.js
+++ b/api/upload.js
@@ -1,4 +1,4 @@
-const { supabase } = require('../lib/supabase');
+import { supabase } from '../lib/supabase.js';
 
 export default async function handler(request) {
   console.log('Upload API: Function started, method:', request.method);

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,4 +1,4 @@
-const { createClient } = require('@supabase/supabase-js');
+import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -7,6 +7,4 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables');
 }
 
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
-
-module.exports = { supabase };
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "AI-powered photo booth with smile detection",
   "main": "index.html",
+  "type": "module",
   "scripts": {
     "dev": "vercel dev",
     "build": "echo 'Static files are in public directory'",


### PR DESCRIPTION
## Summary
- enable native ES modules via package.json
- refactor Supabase client and API routes to use `import`/`export`
- clean up remaining CommonJS exports

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68997a3cebac83248662c8082563468f