### PR TITLE
chore: rename supabase env vars

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,13 +1,13 @@
 # Supabase Configuration
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_URL=your_supabase_project_url
+SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # Instructions:
 # 1. Create a Supabase account at https://supabase.com
 # 2. Create a new project
 # 3. Go to Settings > API
-# 4. Copy your Project URL and paste it as NEXT_PUBLIC_SUPABASE_URL
-# 5. Copy your anon/public key and paste it as NEXT_PUBLIC_SUPABASE_ANON_KEY
+# 4. Copy your Project URL and paste it as SUPABASE_URL
+# 5. Copy your anon/public key and paste it as SUPABASE_ANON_KEY
 # 6. Create a storage bucket named 'photos':
 #    - Go to Storage in your Supabase dashboard
 #    - Click "New bucket"

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,7 +1,7 @@
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables');


### PR DESCRIPTION
## Summary
- use server-only env vars for Supabase client
- document new env var names

## Testing
- `npm test` (fails: Missing script)
- `npm run build`
- `SUPABASE_URL=https://example.com SUPABASE_ANON_KEY=anon node -e "require('./lib/supabase'); console.log('supabase initialized');"`


------
https://chatgpt.com/codex/tasks/task_e_68997dfd2f588324ae9134c7f1ea5ec1