### PR TITLE
Use Vercel image optimization for gallery thumbnails

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -628,8 +628,8 @@ function displayGallery(photos) {
     }
     
     galleryGrid.innerHTML = photos.map(photo => {
-        // Create thumbnail URL with Vercel image optimization
-        const thumbnailUrl = `${photo.url}?width=300&height=225&fit=cover&quality=80`;
+        // Create thumbnail URL using Vercel image optimization service
+        const thumbnailUrl = `/_vercel/image?url=${encodeURIComponent(photo.url)}&w=300&h=225&fit=cover&q=80`;
         
         return `
             <div class="gallery-item" onclick="openPhoto('${photo.url}')">


### PR DESCRIPTION
## Summary
- generate gallery thumbnails using Vercel's `/_vercel/image` service instead of query-string sizing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899814a62e48324bf603d80cc41c791