### PR TITLE
refactor: convert gallery and upload handlers to commonjs

### DIFF
--- a/api/gallery.js
+++ b/api/gallery.js
@@ -1,6 +1,6 @@
 const { supabase } = require('../lib/supabase');
 
-export default async function handler(request) {
+module.exports = async function handler(request) {
   console.log('Gallery API: Function started');
   
   // Add CORS headers

--- a/api/upload.js
+++ b/api/upload.js
@@ -1,6 +1,6 @@
 const { supabase } = require('../lib/supabase');
 
-export default async function handler(request) {
+module.exports = async function handler(request) {
   console.log('Upload API: Function started, method:', request.method);
   
   // Add CORS headers
@@ -104,7 +104,7 @@ export default async function handler(request) {
   }
 }
 
-export const config = {
+module.exports.config = {
   api: {
     bodyParser: {
       sizeLimit: '10mb',


### PR DESCRIPTION
## Summary
- switch upload and gallery APIs to CommonJS handler style
- expose upload config through `module.exports.config`

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689a05d60a148324860065b659294fae