### PR TITLE
refactor: reuse global captureMessage in upload

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -483,7 +483,6 @@ async function uploadToGallery() {
         console.log('Client: Canvas data size:', imageData.length);
         
         // Add visual feedback during upload
-        const captureMessage = document.getElementById('capture-message');
         if (captureMessage) {
             captureMessage.textContent = 'Uploading...';
         }
@@ -538,8 +537,6 @@ async function uploadToGallery() {
         }
     } catch (error) {
         console.error('Client: Upload error:', error);
-        const captureMessage = document.getElementById('capture-message');
-        
         if (error.message === 'Upload timeout') {
             console.error('Client: Upload timed out after 10 seconds');
             if (captureMessage) {


### PR DESCRIPTION
## Summary
- Remove redundant DOM lookup for `captureMessage` inside `uploadToGallery`
- Use globally defined `captureMessage` for upload status updates

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a05d8a25483248761a75181873354