### PR TITLE
Use Vercel dev server for local API routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "AI-powered photo booth with smile detection",
   "main": "index.html",
   "scripts": {
-    "dev": "python3 -m http.server 3000 --directory public",
-    "vercel-dev": "vercel dev",
+    "dev": "vercel dev",
     "build": "echo 'Static files are in public directory'",
     "deploy": "vercel"
   },


### PR DESCRIPTION
## Summary
- Replace the `dev` script with `vercel dev` so API routes can be served locally

## Testing
- `npm run dev` *(fails: Error: No existing credentials found)*
- `node test-supabase.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a20898c5c8324af2eabf7678fffe1