### PR TITLE
refactor: convert project to esm

### DIFF
--- a/api/debug.js
+++ b/api/debug.js
@@ -1,6 +1,6 @@
-const { supabase, bucketName } = require('../lib/supabase');
+import { supabase, bucketName } from '../lib/supabase.js';
 
-module.exports = async function handler(req, res) {
+export default async function handler(req, res) {
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
@@ -66,4 +66,4 @@ module.exports = async function handler(req, res) {
       hasKey: !!process.env.SUPABASE_ANON_KEY,
     });
   }
-};
+}

--- a/api/gallery.js
+++ b/api/gallery.js
@@ -1,7 +1,7 @@
-const { supabase, bucketName } = require('../lib/supabase');
-const { setCorsHeaders } = require('../lib/cors');
+import { supabase, bucketName } from '../lib/supabase.js';
+import { setCorsHeaders } from '../lib/cors.js';
 
-module.exports = async function handler(req, res) {
+export default async function handler(req, res) {
   console.log('Gallery API: Function started');
 
   // Set CORS headers with restricted origins
@@ -62,4 +62,4 @@ module.exports = async function handler(req, res) {
       message: error.message,
     });
   }
-};
+}

--- a/api/test.js
+++ b/api/test.js
@@ -1,4 +1,4 @@
-module.exports = async function handler(req, res) {
+export default async function handler(req, res) {
   console.log('Test API: Function started');
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -9,4 +9,4 @@ module.exports = async function handler(req, res) {
     hasBlob: !!process.env.BLOB_READ_WRITE_TOKEN,
     method: req.method,
   });
-};
+}

--- a/api/upload.js
+++ b/api/upload.js
@@ -1,7 +1,7 @@
-const { supabase, bucketName } = require('../lib/supabase');
-const { setCorsHeaders } = require('../lib/cors');
+import { supabase, bucketName } from '../lib/supabase.js';
+import { setCorsHeaders } from '../lib/cors.js';
 
-module.exports = async function handler(req, res) {
+export default async function handler(req, res) {
   console.log('Upload API: Function started, method:', req.method);
 
   // Set CORS headers with restricted origins
@@ -132,4 +132,4 @@ module.exports = async function handler(req, res) {
       message: error.message,
     });
   }
-};
+}

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -7,7 +7,7 @@ const allowedOrigins = [
   process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null,
 ].filter(Boolean);
 
-function setCorsHeaders(req, res, methods = 'GET, POST, OPTIONS') {
+export function setCorsHeaders(req, res, methods = 'GET, POST, OPTIONS') {
   const origin = req.headers.origin;
   
   // Check if origin is allowed
@@ -22,5 +22,3 @@ function setCorsHeaders(req, res, methods = 'GET, POST, OPTIONS') {
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
 }
-
-module.exports = { setCorsHeaders };

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,4 +1,4 @@
-const { createClient } = require('@supabase/supabase-js');
+import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
@@ -16,12 +16,8 @@ if (!supabaseUrl || !supabaseAnonKey) {
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 // Create service role client for admin operations (if available)
-const supabaseAdmin = supabaseServiceKey 
+const supabaseAdmin = supabaseServiceKey
   ? createClient(supabaseUrl, supabaseServiceKey)
   : null;
 
-module.exports = { 
-  supabase, 
-  supabaseAdmin, 
-  bucketName 
-};
+export { supabase, supabaseAdmin, bucketName };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "AI-powered photo booth with smile detection",
   "main": "index.html",
+  "type": "module",
   "scripts": {
     "dev": "python3 -m http.server 3000 --directory public",
     "vercel-dev": "vercel dev",

--- a/setup-supabase-guide.js
+++ b/setup-supabase-guide.js
@@ -5,8 +5,12 @@
  * This script helps you set up and verify your Supabase storage configuration
  */
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 console.log('🚀 Supabase Storage Setup Guide for Photo Gallery App\n');
 

--- a/verify-policies.js
+++ b/verify-policies.js
@@ -5,8 +5,10 @@
  * This script helps verify that your storage bucket policies are correctly configured
  */
 
-require('dotenv').config({ path: '.env.local' });
-const { supabase } = require('./lib/supabase');
+import dotenv from 'dotenv';
+import { supabase } from './lib/supabase.js';
+
+dotenv.config({ path: '.env.local' });
 
 async function verifyPolicies() {
   console.log('🔒 Verifying Supabase Storage Policies...\n');


### PR DESCRIPTION
## Summary
- enable native ES modules by setting `"type": "module"`
- migrate backend and utility scripts from CommonJS to ES module syntax
- expose CORS helper via ES module export

## Testing
- `node -e "import('@supabase/supabase-js').then(({createClient})=>console.log(typeof createClient))"`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service node -e "import('./lib/supabase.js').then(m=>console.log(Object.keys(m)))"`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anon node -e "import('./api/upload.js').then(m=>console.log(typeof m.default))"`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anon node -e "import('./api/gallery.js').then(m=>console.log(typeof m.default))"`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anon node -e "import('./api/debug.js').then(m=>console.log(typeof m.default))"`
- `node -e "import('./api/test.js').then(m=>console.log(typeof m.default))"`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_URL=http://localhost SUPABASE_ANON_KEY=anon node verify-policies.js`
- `node setup-supabase-guide.js --help`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bc166fd008324b51ce5183265ce0e